### PR TITLE
EmergencyInfo: Allow adding contacts

### DIFF
--- a/src/com/android/emergency/edit/EditInfoFragment.java
+++ b/src/com/android/emergency/edit/EditInfoFragment.java
@@ -91,8 +91,7 @@ public class EditInfoFragment extends PreferenceFragment {
                 // presented with a list of contacts, with one entry per phone number.
                 // The selected contact is guaranteed to have a name and phone number.
                 Intent contactPickerIntent = new Intent(Intent.ACTION_PICK,
-                        ContactsContract.CommonDataKinds.Phone.CONTENT_URI)
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        ContactsContract.CommonDataKinds.Phone.CONTENT_URI);
                 try {
                     startActivityForResult(contactPickerIntent, CONTACT_PICKER_RESULT);
                     return true;


### PR DESCRIPTION
* When using the FLAG_ACTIVITY_NEW_TASK, any waiting for a result
  will not have an effect, see
  https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_TASK
* Also, from the logs:
  ActivityTaskManager: Activity is launching as a new task,
  so cancelling activity result.

Fixes: https://gitlab.com/LineageOS/issues/android/-/issues/4619
Test: Add a new emergency contact
Change-Id: Icd899693967cb4942ba2a4a6689131f45408262e